### PR TITLE
Add Howler controller 

### DIFF
--- a/app/controllers/howlers_controller.rb
+++ b/app/controllers/howlers_controller.rb
@@ -1,0 +1,16 @@
+class HowlersController < ApplicationController
+  def howl
+    howler = Howler.find_by_url(params[:id])
+    if howler && howler.play!
+      Pusher.trigger(pusher_channel, 'howl', {})
+      redirect_to root_url, notice: "Thank you for waking up David!"
+    else
+      redirect_to root_url, notice: "That token was not valid, sorry. You can earn your right to wake up David by <a href='http://www.justgiving.com/100hoursofsolitude'>donating at least $50 here</a>."
+    end
+  end
+
+  private 
+  def pusher_channel
+    "#{Rails.env}_main_channel"
+  end
+end

--- a/app/models/howler.rb
+++ b/app/models/howler.rb
@@ -1,0 +1,8 @@
+class Howler < ActiveRecord::Base
+  def play!
+    return false unless self.charges && self.charges > 0
+    self.charges -= 1
+    self.played_at = Time.now
+    self.save
+  end
+end

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -2,4 +2,4 @@
   - if msg.is_a?(String)
     %div{:class => "alert alert-#{name == :notice ? "success" : "error"}"}
       %a.close{"data-dismiss" => "alert"} ×
-      = content_tag :div, msg, :id => "flash_#{name}"
+      = content_tag :div, raw(msg), :id => "flash_#{name}"

--- a/config/initializers/pusher.rb
+++ b/config/initializers/pusher.rb
@@ -1,0 +1,5 @@
+require 'pusher'
+
+Pusher.app_id = 32501
+Pusher.key = '8146487894a3cc81758c' # This isn't secret
+Pusher.secret = ENV['PUSHER_SECRET']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ HundredHours::Application.routes.draw do
   resource :feedback, :only => [:new, :create, :show]
   match "about" => "pages#about"
   match "style" => "pages#style"
+  match "howl/:id" => "howlers#howl"
   root :to => "home#index"
 end


### PR DESCRIPTION
When a user hits /play/:url_token with a valid token for a howler that still holds charges, it plays the howler, by sending a message of type "howl" to Pusher.

Fixes #21 

poke @heeton 
